### PR TITLE
feat(#10): Throw Exception If `javac` Is Absent

### DIFF
--- a/src/main/java/com/yegor256/Jhome.java
+++ b/src/main/java/com/yegor256/Jhome.java
@@ -95,9 +95,7 @@ public final class Jhome {
      */
     public Path javac() {
         final Path path = this.path(String.format("bin/javac%s", Jhome.extension()));
-        if (Files.exists(path)) {
-            return path;
-        } else {
+        if (!Files.exists(path)) {
             throw new IllegalStateException(
                 String.format(
                     "javac binary file doesn't exist in the home folder '%s'. Try to change home folder, or check if JDK is installed correctly.",
@@ -105,6 +103,7 @@ public final class Jhome {
                 )
             );
         }
+        return path;
     }
 
     /**

--- a/src/main/java/com/yegor256/Jhome.java
+++ b/src/main/java/com/yegor256/Jhome.java
@@ -53,7 +53,15 @@ public final class Jhome {
      * Ctor.
      */
     public Jhome() {
-        this.home = Jhome.base();
+        this(Jhome.base());
+    }
+
+    /**
+     * Constructor.
+     * @param home The home.
+     */
+    public Jhome(final Path home) {
+        this.home = home;
     }
 
     /**

--- a/src/main/java/com/yegor256/Jhome.java
+++ b/src/main/java/com/yegor256/Jhome.java
@@ -24,6 +24,7 @@
 package com.yegor256;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -93,7 +94,17 @@ public final class Jhome {
      *  {@code Optional<Path>} is also a solution here.
      */
     public Path javac() {
-        return this.path(String.format("bin/javac%s", Jhome.extension()));
+        final Path path = this.path(String.format("bin/javac%s", Jhome.extension()));
+        if (Files.exists(path)) {
+            return path;
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "javac binary file doesn't exist in the home folder '%s'. Try to change home folder, or check if JDK is installed correctly.",
+                    this.home
+                )
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -112,6 +112,7 @@ final class JhomeTest {
             "Should throw IllegalStateException if javac binary file doesn't exist"
         );
         MatcherAssert.assertThat(
+            "Exception message should contain the path to the home folder",
             exception.getMessage(),
             Matchers.stringContainsInOrder(
                 String.format("javac binary file doesn't exist in the home folder '%s'", temp)

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -105,15 +105,13 @@ final class JhomeTest {
 
     @Test
     void throwsIfJavacNotFound(final @TempDir Path temp) {
-        final Jhome jhome = new Jhome(temp);
-        final IllegalStateException exception = Assertions.assertThrows(
-            IllegalStateException.class,
-            jhome::javac,
-            "Should throw IllegalStateException if javac binary file doesn't exist"
-        );
         MatcherAssert.assertThat(
             "Exception message should contain the path to the home folder",
-            exception.getMessage(),
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Jhome(temp)::javac,
+                "Should throw IllegalStateException if javac binary file doesn't exist"
+            ).getMessage(),
             Matchers.stringContainsInOrder(
                 String.format("javac binary file doesn't exist in the home folder '%s'", temp)
             )

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -108,7 +108,8 @@ final class JhomeTest {
         final Jhome jhome = new Jhome(temp);
         final IllegalStateException exception = Assertions.assertThrows(
             IllegalStateException.class,
-            jhome::javac
+            jhome::javac,
+            "Should throw IllegalStateException if javac binary file doesn't exist"
         );
         MatcherAssert.assertThat(
             exception.getMessage(),

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -31,12 +31,14 @@ import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Jhome}.
@@ -98,6 +100,21 @@ final class JhomeTest {
             ),
             file,
             FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    void throwsIfJavacNotFound(final @TempDir Path temp) {
+        final Jhome jhome = new Jhome(temp);
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            jhome::javac
+        );
+        MatcherAssert.assertThat(
+            exception.getMessage(),
+            Matchers.stringContainsInOrder(
+                String.format("javac binary file doesn't exist in the home folder '%s'", temp)
+            )
         );
     }
 


### PR DESCRIPTION
Throw exception if `javac` binary wasn't found.

Closes: #10.
____
History:
- feat(#10): add unit test for the future implementation
- feat(#10): add implementation
