### PR TITLE
Upgrade jcabi parent and qulice to latest stable

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022]
-        java: [17, 23]
+        java: [21, 23]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.0</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.70.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>jhome</artifactId>

--- a/src/main/java/com/yegor256/Jhome.java
+++ b/src/main/java/com/yegor256/Jhome.java
@@ -27,6 +27,11 @@ import java.util.Locale;
 public final class Jhome {
 
     /**
+     * Default home, computed from {@code java.home} or {@code JAVA_HOME}.
+     */
+    private static final Path DEFAULT_HOME = Jhome.base();
+
+    /**
      * Home, where {@code JAVA_HOME} points to.
      */
     private final Path home;
@@ -35,12 +40,12 @@ public final class Jhome {
      * Ctor.
      */
     public Jhome() {
-        this(Jhome.base());
+        this(Jhome.DEFAULT_HOME);
     }
 
     /**
      * Constructor.
-     * @param home The home.
+     * @param home The home
      */
     public Jhome(final Path home) {
         this.home = home;
@@ -48,7 +53,7 @@ public final class Jhome {
 
     /**
      * Find the file inside {@code JAVA_HOME}.
-     * @param loc Location, e.g. {@code "bin/java"} relative to {@code JAVA_HOME}.
+     * @param loc Location, e.g. {@code "bin/java"} relative to {@code JAVA_HOME}
      * @return The path of it
      */
     public Path path(final String... loc) {
@@ -84,7 +89,7 @@ public final class Jhome {
 
     /**
      * Check if {@code javac} binary exists.
-     * @return True if it exists.
+     * @return True if it exists
      */
     public boolean javacExists() {
         return Files.exists(this.javacPath());
@@ -92,7 +97,7 @@ public final class Jhome {
 
     /**
      * Find the {@code javac} binary.
-     * @return The path of it.
+     * @return The path of it
      */
     private Path javacPath() {
         return this.path(String.format("bin/javac%s", Jhome.extension()));
@@ -102,7 +107,7 @@ public final class Jhome {
      * Find the extension of the executable file.
      * - On Windows it is ".exe".
      * - On Unix it is empty string.
-     * @return The extension.
+     * @return The extension
      */
     private static String extension() {
         final String result;

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link Jhome}.
- *
  * @since 0.1.0
  */
 final class JhomeTest {
@@ -54,7 +53,7 @@ final class JhomeTest {
                 file,
                 Files.list(new Jhome().path("bin"))
                     .map(Path::toString)
-                    .collect(Collectors.joining("\n"))
+                    .collect(Collectors.joining(System.lineSeparator()))
             ),
             file,
             FileMatchers.anExistingFile()
@@ -76,7 +75,7 @@ final class JhomeTest {
                 file,
                 Files.list(new Jhome().path("bin"))
                     .map(Path::toString)
-                    .collect(Collectors.joining("\n"))
+                    .collect(Collectors.joining(System.lineSeparator()))
             ),
             file,
             FileMatchers.anExistingFile()

--- a/src/test/java/com/yegor256/JhomeTest.java
+++ b/src/test/java/com/yegor256/JhomeTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -68,7 +67,7 @@ final class JhomeTest {
      * JRE pack did not contain it.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_9)
+    @EnabledForJreRange(minVersion = 9)
     void findsJavacOnAnyOs() throws IOException {
         final File file = new Jhome().javac().toFile();
         MatcherAssert.assertThat(
@@ -137,7 +136,7 @@ final class JhomeTest {
      * After Java 9, we might be sure that javac is installed.
      */
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_9)
+    @EnabledForJreRange(minVersion = 9)
     void checksIfJavacExists() {
         MatcherAssert.assertThat(
             "Javac binary file doesn't exist, but it should",

--- a/src/test/java/com/yegor256/package-info.java
+++ b/src/test/java/com/yegor256/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Tests for the main class.
- *
  * @since 0.0.1
  */
 package com.yegor256;


### PR DESCRIPTION
@yegor256, this PR brings `com.jcabi:parent` and `com.qulice:qulice-maven-plugin` to their latest stable versions, fixes the resulting linter and compiler errors, and adjusts the CI matrix accordingly.

## Changes (3 commits)

### 1. Bump `com.jcabi:parent` 0.70.0 → 0.73.1

The newer parent brings JUnit Jupiter 5.13+, where `JRE.JAVA_9` is annotated `@Deprecated(forRemoval = true)`. With the parent's `-Werror`/`-Xlint:deprecation` settings, this turned into a hard compile error. Switched the affected `@EnabledForJreRange` annotations to use the integer `minVersion = 9` form and removed the now-unused `JRE` import.

### 2. Bump `com.qulice:qulice-maven-plugin` 0.25.0 → 0.27.5

The newer Qulice introduces tighter Checkstyle rules. Fixed the violations rather than suppressing them:

- **`ConstructorsCodeFreeCheck`**: the no-arg constructor previously called `Jhome.base()` while delegating with `this(...)`. Cached the default `JAVA_HOME` in a `private static final Path DEFAULT_HOME` so the constructor delegates with a field reference and contains no method calls. `java.home` is set by the JVM at startup, so eager evaluation is safe.
- **`JavadocTagsDotCheck`**: dropped trailing dots from `@param` and `@return` tag descriptions in `Jhome.java`.
- **`JavadocEmptyLineBeforeTagCheck`**: removed the blank line between single-paragraph descriptions and `@since` tags in `JhomeTest.java` and the test `package-info.java`.
- **`ProhibitLineSeparatorInStringsCheck`**: replaced two literal `\n` joiners with `System.lineSeparator()`.

### 3. Drop JDK 17 from the `mvn` CI matrix

Qulice 0.27.5 (and the underlying Checkstyle 13) is compiled against Java 21 — its plugin classes load with class file version 65, which the JDK 17 runtime cannot read (`UnsupportedClassVersionError: ... class file version 65.0`, JDK 17 only handles up to 61.0). Bumped the matrix from `[17, 23]` to `[21, 23]`. The compiled artifact still targets Java 1.8 via the parent POM, so library consumers are unaffected.

## Verification

* `mvn --errors --batch-mode clean install -Pqulice` passes locally on JDK 21 and JDK 17 fails identically to CI as expected (qulice class version error).
* All workflows are green on my fork: https://github.com/bibonix/jhome/actions/runs/25027338551 — `mvn` matrix passes on `ubuntu-24.04`, `windows-2022`, `macos-15` × `[21, 23]`, plus `actionlint`, `codecov`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`.